### PR TITLE
some bug fix:

### DIFF
--- a/ports/nxp_rt1050_60/omv/cambus.c
+++ b/ports/nxp_rt1050_60/omv/cambus.c
@@ -81,6 +81,7 @@ int cambus_init()
      * 111 divide by 8
      */
     CLOCK_SetDiv(kCLOCK_CsiDiv, 0);
+	CLOCK_EnableClock(kCLOCK_Csi);
 
     /*
      * For RT1050, there is not dedicate clock gate for CSI MCLK, it use CSI

--- a/ports/nxp_rt1050_60/omv/sensor.c
+++ b/ports/nxp_rt1050_60/omv/sensor.c
@@ -615,7 +615,6 @@ RAM_CODE void CSI_IRQHandler(void)
 
 void CsiFragModeInit(void) {
 
-	CLOCK_EnableClock(kCLOCK_Csi);
 	CSI_Reset(CSI);
 	
 	s_pCSI->CSICR1 = CSICR1_INIT_VAL;
@@ -763,7 +762,7 @@ int sensor_init()
     } else { // Read OV sensor ID.
         cambus_readb(s_sensor.slv_addr, OV_CHIP_ID, &s_sensor.chip_id);
         // Initialize sensor struct.
-        switch (119) {
+        switch (s_sensor.chip_id) {
             case OV9650_ID:
                 ov9650_init(&s_sensor);
                 break;


### PR DESCRIPTION
1. using camer_id instead a const value
2. Enable the csi clock before calling the cambus_readb(), causing the camera id read failed, and place it
into cambus_init

Signed-off-by: CristXu <crist.xy@nxp.com>